### PR TITLE
Back button in header nav. in Pinmap is now removed

### DIFF
--- a/Bikeini/navigation/AppNavigator.js
+++ b/Bikeini/navigation/AppNavigator.js
@@ -26,7 +26,13 @@ const AppNavigator = createStackNavigator({
     },
   },
   BikeInformation: { screen: BikeInformation },
-  PinMap: { screen: PinMap },
+  PinMap: {
+    screen: PinMap,
+    navigationOptions: {
+      headerLeft: null,
+      gesturesEnabled: false,
+    },
+  },
   EditProfile: { screen: EditProfile },
   TabNavigator: {
     screen: TabNavigator,


### PR DESCRIPTION
#### What does this PR do?
Removes backbutton in pinmap header navigation.
[Issue](#226 )

##### Why are we doing this? Any context or related work?
So users can set locations after looking at another ads location.
#### Where should a reviewer start?
AppNavigator.js
#### Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
closes #226 